### PR TITLE
Tycho 0.21.0 needed for Maven > 3.1

### DIFF
--- a/familiar.root/pom.xml
+++ b/familiar.root/pom.xml
@@ -20,8 +20,8 @@
   </modules>
 
   <properties>
-    <tycho.version>0.18.0</tycho.version>
-    <tycho-extras.version>0.18.0</tycho-extras.version>
+    <tycho.version>0.21.0</tycho.version>
+    <tycho-extras.version>0.21.0</tycho-extras.version>
 	<obeodesigner-repo.url>http://www.obeo.fr/download/release/designer/6.1/latest/juno3/update/</obeodesigner-repo.url>
     <featureide-repo.url>http://wwwiti.cs.uni-magdeburg.de/iti_db/research/featureide/deploy/</featureide-repo.url>
     <kepler-repo.url>http://download.eclipse.org/releases/kepler/</kepler-repo.url>


### PR DESCRIPTION
Maven > 3.1 has some incompatibilities with old versions of Tycho. On my desktop, I cannot _cd familiar.root && mvn install_:

```
Exception in thread "main" java.lang.NoSuchMethodError: org.apache.maven.execution.MavenSession.getRepositorySession()Lorg/sonatype/aether/RepositorySystemSession;
        at org.eclipse.tycho.core.maven.utils.PluginRealmHelper.execute(PluginRealmHelper.java:92)
        at org.eclipse.tycho.p2.resolver.P2TargetPlatformResolver.getDependencyMetadata(P2TargetPlatformResolver.java:144)
        at org.eclipse.tycho.p2.resolver.P2TargetPlatformResolver.setupProjects(P2TargetPlatformResolver.java:126)
        at org.eclipse.tycho.core.resolver.DefaultTychoDependencyResolver.setupProject(DefaultTychoDependencyResolver.java:87)
        at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.afterProjectsRead(TychoMavenLifecycleParticipant.java:77)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:310)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:154)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:582)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:214)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:158)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:483)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
```

The attached commit solves the problem by updating the POM configuration to Tycho 0.21.0
